### PR TITLE
Handle disabling edge cases

### DIFF
--- a/lib/assets/javascripts/vanilla-ujs/disable.js
+++ b/lib/assets/javascripts/vanilla-ujs/disable.js
@@ -1,7 +1,20 @@
 document.addEventListener('click', function (event) {
   var message, element;
 
+  // do not disable on right click. Work on left and middle click
+  if (event.which == 3) {
+    return;
+  }
+
   element = event.target;
+
+  // do not disable if the element is a submit button and its form has invalid input elements.
+  // since failed validations prevent the form from being submitted, we would lock the form permanently
+  // by disabling the submit button even though the form was never submitted
+
+  if(element.getAttribute("type") === "submit" && element.form.querySelector(":invalid") !== null) {
+    return;
+  }
 
   if (matches.call(element, 'a[data-disable-with], button[data-disable-with], input[data-disable-with]')) {
     message = element.getAttribute('data-disable-with');


### PR DESCRIPTION
Currently, right-clicking a link will disable it if it has a disable-with attribute, even though right clicky typically do not trigger any action.

Forms can have integrated validations (i.e. fields need to be filled or conform to a pattern). Submitting a form with invalid input elements will show a browser message asking to amend the error rather than submitting a form. However, we currently disable the submit button regardless of such validations.

This pull request addresses both of these issues.